### PR TITLE
Fix appfs bootloader code

### DIFF
--- a/factory_test/bootloader_components/main/bootloader_start.c
+++ b/factory_test/bootloader_components/main/bootloader_start.c
@@ -109,6 +109,9 @@ void __attribute__((noreturn)) call_start_cpu0(void)
 
 	ESP_LOGI(TAG, "Wrapping flash functions and booting app...");
 	appfs_wrapper_init(handle, appfs_pos, appfs_len);
+	//De-init the high-level parts of appfs. Reading/mmap'ping a file handle still is explicitly
+	//allowed after this, though.
+	appfsBlDeinit();
 	//Note that the rest of the bootloader code has no clue about appfs, and as such won't try
 	//to boot it. We 'fix' that by chucking the appfs partition (which is now wrapped so the rest
 	//of the bootloader reads from the selected file when it thinks it loads from the app) into

--- a/factory_test/components/appfs/appfs.h
+++ b/factory_test/components/appfs/appfs.h
@@ -242,7 +242,8 @@ typedef struct {
 esp_err_t appfsBlInit(uint32_t offset, uint32_t len);
 
 /**
- * @brief Bootloader only: de-init appfs
+ * @brief Bootloader only: de-init appfs. Note that if you have a file handle, you can still
+ *        read/mmap it. This guarantees that the metadata for the appfs is not mapped anymore.
  */
 void appfsBlDeinit();
 /**
@@ -261,6 +262,18 @@ void* appfsBlMmap(int fd);
  * @brief Bootloader only: Un-mmap a file
  */
 void appfsBlMunmap();
+
+
+/**
+ * @brief Bootloader only: read data from a file
+ *
+ * @param fs File descriptor to read from
+ * @param src_addr Offset in file
+ * @param dest Dest buffer
+ * @param size Length to read
+ * @return ESP_OK if OK
+ */
+esp_err_t appfs_bootloader_read(int fd, size_t src_addr, void *dest, size_t size);
 
 /*
  * @brief Bootloader only: map multiple regions within a file to various memory addressed.


### PR DESCRIPTION
Fix appfs bootloader code so appfs loading works; fix fallback to factory app when appfs app is corrupted.

This now succesfully boots into an app.