### PR TITLE
Update PAX, fix some graphics calls.

### DIFF
--- a/main/button_test.c
+++ b/main/button_test.c
@@ -8,6 +8,8 @@
 #include "rp2040.h"
 
 void test_buttons(xQueueHandle buttonQueue, pax_buf_t* pax_buffer, ILI9341* ili9341) {
+    const pax_font_t *font = pax_get_font("saira regular");
+    
     bool render = true;
     bool quit = false;
 
@@ -94,30 +96,30 @@ void test_buttons(xQueueHandle buttonQueue, pax_buf_t* pax_buffer, ILI9341* ili9
         if (render) {
             pax_noclip(pax_buffer);
             pax_background(pax_buffer, 0x325aa8);
-            pax_draw_text(pax_buffer, 0xFFFFFFFF, NULL, 18, 0, 20*0, "Press HOME + START to exit");
+            pax_draw_text(pax_buffer, 0xFFFFFFFF, font, 18, 0, 20*0, "Press HOME + START to exit");
             char buffer[64];
             snprintf(buffer, sizeof(buffer), "JOY DOWN   %s", btn_joy_down ? "PRESSED" : "released");
-            pax_draw_text(pax_buffer, btn_joy_down_green ? 0xFF00FF00 : 0xFFFFFFFF, NULL, 18, 0, 20*1, buffer);
+            pax_draw_text(pax_buffer, btn_joy_down_green ? 0xFF00FF00 : 0xFFFFFFFF, font, 18, 0, 20*1, buffer);
             snprintf(buffer, sizeof(buffer), "JOY UP     %s", btn_joy_up ? "PRESSED" : "released");
-            pax_draw_text(pax_buffer, btn_joy_up_green ? 0xFF00FF00 : 0xFFFFFFFF, NULL, 18, 0, 20*2, buffer);
+            pax_draw_text(pax_buffer, btn_joy_up_green ? 0xFF00FF00 : 0xFFFFFFFF, font, 18, 0, 20*2, buffer);
             snprintf(buffer, sizeof(buffer), "JOY LEFT   %s", btn_joy_left ? "PRESSED" : "released");
-            pax_draw_text(pax_buffer, btn_joy_left_green ? 0xFF00FF00 : 0xFFFFFFFF, NULL, 18, 0, 20*3, buffer);
+            pax_draw_text(pax_buffer, btn_joy_left_green ? 0xFF00FF00 : 0xFFFFFFFF, font, 18, 0, 20*3, buffer);
             snprintf(buffer, sizeof(buffer), "JOY RIGHT  %s", btn_joy_right ? "PRESSED" : "released");
-            pax_draw_text(pax_buffer, btn_joy_right_green ? 0xFF00FF00 : 0xFFFFFFFF, NULL, 18, 0, 20*4, buffer);
+            pax_draw_text(pax_buffer, btn_joy_right_green ? 0xFF00FF00 : 0xFFFFFFFF, font, 18, 0, 20*4, buffer);
             snprintf(buffer, sizeof(buffer), "JOY PRESS  %s", btn_joy_press ? "PRESSED" : "released");
-            pax_draw_text(pax_buffer, btn_joy_press_green ? 0xFF00FF00 : 0xFFFFFFFF, NULL, 18, 0, 20*5, buffer);
+            pax_draw_text(pax_buffer, btn_joy_press_green ? 0xFF00FF00 : 0xFFFFFFFF, font, 18, 0, 20*5, buffer);
             snprintf(buffer, sizeof(buffer), "BTN HOME   %s", btn_home ? "PRESSED" : "released");
-            pax_draw_text(pax_buffer, btn_home_green ? 0xFF00FF00 : 0xFFFFFFFF, NULL, 18, 0, 20*6, buffer);
+            pax_draw_text(pax_buffer, btn_home_green ? 0xFF00FF00 : 0xFFFFFFFF, font, 18, 0, 20*6, buffer);
             snprintf(buffer, sizeof(buffer), "BTN MENU   %s", btn_menu ? "PRESSED" : "released");
-            pax_draw_text(pax_buffer, btn_menu_green ? 0xFF00FF00 : 0xFFFFFFFF, NULL, 18, 0, 20*7, buffer);
+            pax_draw_text(pax_buffer, btn_menu_green ? 0xFF00FF00 : 0xFFFFFFFF, font, 18, 0, 20*7, buffer);
             snprintf(buffer, sizeof(buffer), "BTN SELECT %s", btn_select ? "PRESSED" : "released");
-            pax_draw_text(pax_buffer, btn_select_green ? 0xFF00FF00 : 0xFFFFFFFF, NULL, 18, 0, 20*8, buffer);
+            pax_draw_text(pax_buffer, btn_select_green ? 0xFF00FF00 : 0xFFFFFFFF, font, 18, 0, 20*8, buffer);
             snprintf(buffer, sizeof(buffer), "BTN START  %s", btn_start ? "PRESSED" : "released");
-            pax_draw_text(pax_buffer, btn_start_green ? 0xFF00FF00 : 0xFFFFFFFF, NULL, 18, 0, 20*9, buffer);
+            pax_draw_text(pax_buffer, btn_start_green ? 0xFF00FF00 : 0xFFFFFFFF, font, 18, 0, 20*9, buffer);
             snprintf(buffer, sizeof(buffer), "BTN A      %s", btn_accept ? "PRESSED" : "released");
-            pax_draw_text(pax_buffer, btn_accept_green ? 0xFF00FF00 : 0xFFFFFFFF, NULL, 18, 0, 20*10, buffer);
+            pax_draw_text(pax_buffer, btn_accept_green ? 0xFF00FF00 : 0xFFFFFFFF, font, 18, 0, 20*10, buffer);
             snprintf(buffer, sizeof(buffer), "BTN B      %s", btn_back ? "PRESSED" : "released");
-            pax_draw_text(pax_buffer, btn_back_green ? 0xFF00FF00 : 0xFFFFFFFF, NULL, 18, 0, 20*11, buffer);
+            pax_draw_text(pax_buffer, btn_back_green ? 0xFF00FF00 : 0xFFFFFFFF, font, 18, 0, 20*11, buffer);
             ili9341_write(ili9341, pax_buffer->buf);
             render = false;
         }

--- a/main/fpga_download.c
+++ b/main/fpga_download.c
@@ -139,6 +139,7 @@ static void fpga_display_message(
     line = 0;
     m = c = message;
 
+    const pax_font_t *font = pax_get_font("saira regular");
     while (!done) {
         // End ?
         done = (*c == '\0');
@@ -146,7 +147,7 @@ static void fpga_display_message(
         // Print ?
         if (*c == '\0' || *c == '\n') {
             *c = '\0';
-            pax_draw_text(pax_buffer, fg, NULL, 18, 0, 20*line, m);
+            pax_draw_text(pax_buffer, fg, font, 18, 0, 20*line, m);
             m = c + 1;
             line++;
         }

--- a/main/rp2040_updater.c
+++ b/main/rp2040_updater.c
@@ -22,19 +22,18 @@ extern const uint8_t rp2040_firmware_bin_end[] asm("_binary_rp2040_firmware_bin_
 #define RP2040_FIRMWARE_ADDR 0x10010000
 #define RP2040_SECTOR_SIZE 0x1000
 
-void pax_draw_text_centered(pax_buf_t* pax_buffer, const pax_font_t* font, pax_col_t color, int offset, const char* text) {
-    pax_vec1_t size = pax_text_size(font, 18, text);
-    pax_draw_text(pax_buffer, color, font, 18, (320 / 2) - (size.x / 2), (240 / 2) - (size.y / 2) + offset, text);
+static void draw_text_centered(pax_buf_t* pax_buffer, const pax_font_t* font, pax_col_t color, int offset, const char* text) {
+    pax_center_text(pax_buffer, color, font, 18, pax_buffer->width/2, pax_buffer->height/2+offset, text);
 }
 
 void display_rp2040_update_state(pax_buf_t* pax_buffer, ILI9341* ili9341, const char* text1, const char* text2) {
     pax_noclip(pax_buffer);
     const pax_font_t *font = pax_get_font("saira regular");
     pax_background(pax_buffer, 0xFFFFFF);
-    pax_draw_text_centered(pax_buffer, font, 0xFF000000, -16, "Co-processor update");
-    pax_draw_text_centered(pax_buffer, font, 0xFF000000, 8, text1);
+    draw_text_centered(pax_buffer, font, 0xFF000000, -16, "Co-processor update");
+    draw_text_centered(pax_buffer, font, 0xFF000000, 8, text1);
     if (text2 != NULL) {
-        pax_draw_text_centered(pax_buffer, font, 0xFF000000, 32, text2);
+        draw_text_centered(pax_buffer, font, 0xFF000000, 32, text2);
     }
     ili9341_write(ili9341, pax_buffer->buf);
 }
@@ -43,8 +42,8 @@ void display_rp2040_update_error(pax_buf_t* pax_buffer, ILI9341* ili9341, const 
     pax_noclip(pax_buffer);
     const pax_font_t *font = pax_get_font("saira regular");
     pax_background(pax_buffer, 0xa85a32);
-    pax_draw_text_centered(pax_buffer, font, 0xFFFFFFFF, -8, "ERROR");
-    pax_draw_text_centered(pax_buffer, font, 0xFFFFFFFF, 8, text);
+    draw_text_centered(pax_buffer, font, 0xFFFFFFFF, -8, "ERROR");
+    draw_text_centered(pax_buffer, font, 0xFFFFFFFF, 8, text);
     ili9341_write(ili9341, pax_buffer->buf);
 }
 
@@ -55,18 +54,18 @@ void display_rp2040_update_old_bootloader(pax_buf_t* pax_buffer, ILI9341* ili934
 
     int line_height = 16;
 
-    pax_draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*-7, "Hi there prototype user,");
-    pax_draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*-6, "please flash the new bootloader!");
+    draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*-7, "Hi there prototype user,");
+    draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*-6, "please flash the new bootloader!");
 
-    pax_draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*-4, "You can do so by downloading");
-    pax_draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*-3, "the UF2 file at the site below.");
+    draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*-4, "You can do so by downloading");
+    draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*-3, "the UF2 file at the site below.");
 
-    pax_draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*-1, "Hold SELECT while powering on");
-    pax_draw_text_centered(pax_buffer, font, 0xFFFFFFFF, 0, "your badge and copy the file to");
-    pax_draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*1, "the RPI-R2 disk that appears.");
+    draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*-1, "Hold SELECT while powering on");
+    draw_text_centered(pax_buffer, font, 0xFFFFFFFF, 0, "your badge and copy the file to");
+    draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*1, "the RPI-R2 disk that appears.");
 
-    pax_draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*3, "ota.bodge.team/mch2022.uf2");
-    pax_draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*4, "(that's bodge, with an o)");
+    draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*3, "ota.bodge.team/mch2022.uf2");
+    draw_text_centered(pax_buffer, font, 0xFFFFFFFF, line_height*4, "(that's bodge, with an o)");
     ili9341_write(ili9341, pax_buffer->buf);
 }
 


### PR DESCRIPTION
Not very high prio.
Also, please don't use the `pax_` prefix outside of the actual pax submodules.
Centering text is now a built-in feature of PAX.