### PR TITLE
fpga_util: Fix use-after-free in _fpga_req_delete_entry

### DIFF
--- a/main/fpga_util.c
+++ b/main/fpga_util.c
@@ -436,6 +436,9 @@ _fpga_req_delete_entry(uint32_t fid)
             if (re->fh)
                 fclose(re->fh);
             free(re);
+
+            // Done
+            return;
         }
 
         // Next


### PR DESCRIPTION
No need to continue the scan once we deleted the entry ...

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>