### PR TITLE
tunring off led's when changing theme (brightness hurt's in the dark)

### DIFF
--- a/main/nametag.c
+++ b/main/nametag.c
@@ -74,6 +74,7 @@ static void show_name(xQueueHandle button_queue, pax_buf_t *pax_buffer, ILI9341 
         pax_center_text(pax_buffer, 0xFFFFFFFF, title_font, 30, pax_buffer->width / 2, 2, "HELLO");
         pax_center_text(pax_buffer, 0xFFFFFFFF, title_font, 24, pax_buffer->width / 2, 30, "My name is:");
         pax_center_text(pax_buffer, 0xFF000000, name_font, scale, pax_buffer->width / 2, 60 + ((pax_buffer->height - 90) - dims.y) / 2, name);
+        ws2812_send_data(led_off, sizeof(led_off));
     } else if (theme == NICKNAME_THEME_GAMER) {
         int hue = esp_random() & 255;
         pax_col_t color = pax_col_hsv(hue, 255 /*saturation*/, 255 /*brighness*/);
@@ -98,6 +99,7 @@ static void show_name(xQueueHandle button_queue, pax_buf_t *pax_buffer, ILI9341 
     } else {
         pax_background(pax_buffer, 0x000000);
         pax_center_text(pax_buffer, 0xFFFFFFFF, name_font, scale, pax_buffer->width / 2, (pax_buffer->height - dims.y) / 2, name);
+        ws2812_send_data(led_off, sizeof(led_off));
     }
 
     if (instructions) {


### PR DESCRIPTION
Compiled correctly. Didn't tested on the badge yet (don't have a cable)

During night time, when you go from name tag in gamer theme to any other mode, the LED freezes and stay on (even in dark mode). During the night, those lights seems very bright.

This turns them off when theme is changed