### PR TITLE
Add malloc error checks, avoid double allocation of data block

### DIFF
--- a/main/include/fpga_download.h
+++ b/main/include/fpga_download.h
@@ -4,5 +4,5 @@
 
 #include "ice40.h"
 
-void fpga_download(xQueueHandle button_queue, ICE40* ice40);
+bool fpga_download(xQueueHandle button_queue, ICE40* ice40);
 bool fpga_host(xQueueHandle button_queue, ICE40* ice40, bool enable_uart, const char* prefix);

--- a/main/include/fpga_util.h
+++ b/main/include/fpga_util.h
@@ -61,7 +61,8 @@ bool fpga_btn_forward_events(ICE40 *ice40, xQueueHandle buttonQueue, esp_err_t *
 void fpga_req_setup(void);
 void fpga_req_cleanup(void);
 int  fpga_req_add_file_alias(uint32_t fid, const char *path);
-int  fpga_req_add_file_data(uint32_t fid, void *data, size_t len);
+int  fpga_req_add_file_data(uint32_t fid, void *data, size_t len, bool capture_buffer);
 void fpga_req_del_file(uint32_t fid);
+int  fpga_req_buffer_header_size();
 
 bool fpga_req_process(const char *prefix, ICE40 *ice40, TickType_t wait, esp_err_t *err);

--- a/main/main.c
+++ b/main/main.c
@@ -434,7 +434,8 @@ void app_main(void) {
     } else if (webusb_mode == 0x02) {
         display_boot_screen("FPGA download mode");
         while (true) {
-            fpga_download(rp2040->queue, ice40);
+            bool ok = fpga_download(rp2040->queue, ice40);
+            if (!ok) break;
         }
     } else if (webusb_mode == 0x03) {
         webusb_new_main(rp2040->queue);


### PR DESCRIPTION
This PR includes the following:
- Adds a couple of missing malloc error checks.
- Changes the infinite loop around `fpga_download` to exit in case of an error. The badge is then stuck on the last displayed error, preventing continuation after an error.
- Changes `fpga_req_add_file_data` with an option to capture the buffer given in parameter, as well as the caller so the buffer is padded with the header required for the list record. This avoid a double allocation of the data block.
